### PR TITLE
Fix next.js' image src whitelist

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -1,5 +1,5 @@
 module.exports = {
     images: {
-      domains: ["wikimedia.org"]
+      domains: ["upload.wikimedia.org"]
     },
   }


### PR DESCRIPTION
There was a typo in the whitelist that caused images on the editor page to be blocked. This pull request fixes the typo.